### PR TITLE
Use recursive fn inside of a recursive fn

### DIFF
--- a/fibonacci.rs
+++ b/fibonacci.rs
@@ -43,7 +43,7 @@ pub fn fibonacci_reccursive(n: i32) -> u64 {
 		/*
 		50    => 12586269025,
 		*/
-		_     => fibonacci(n - 1) + fibonacci(n - 2)
+		_     => fibonacci_reccursive(n - 1) + fibonacci_reccursive(n - 2)
 	}
 }
 


### PR DESCRIPTION
Hi, I found your fibonacci example a bit confusing - I was surprised, that it calls iterator version inside. It gives a fault impression that Rust does not `stack overflow` when you calculate too large number :)